### PR TITLE
Oboe Request: Return this

### DIFF
--- a/lib/oboeRequest.js
+++ b/lib/oboeRequest.js
@@ -48,13 +48,16 @@ class OboeRequest {
       }
     })
     this._request.node(this._getNodes(callbacks));
+
+    return this;
   }
 
   /**
    * Abort an ongoing request.
    */
   abort() {
-    this._request.abort()
+    this._request.abort();
+    return this;
   }
 
   /**


### PR DESCRIPTION
I found a problem with Oboe Request:

When you create a stream: 

```javascript
const stream = client.stream({}, {});
```
Stream it's undefined because in `client.js` returns: 
```javascript
return oboeRequest.create(opc).stream(opc, callbacks)
```
and the method `stream` of `OboeRequest` doesn't return itself. So if anyone wants to abort the query they can't. 

@alexfernandez 
