### PR TITLE
chore(GH Actions): fix config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -28,12 +28,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm i
-    - run: npm run build --if-present
-    - run: npm test
+    - run: npm ci
+    - run: npm run dist
+    - run: npm t
     - uses: actions/upload-artifact@v2  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
         name: test-results
         path: test-report.json
-

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm test
+      - run: npm run dist
+      - run: npm t
 
   publish-npm:
     needs: build

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install all dependencies:
 
 ```
 cd browser-sdk
-npm install
+npm ci
 ```
 
 Place your Devo [credentials](#Credentials) in the root of the project
@@ -129,7 +129,7 @@ Open this page in a browser in localhost to try out the capabilities in action.
 
 To install the SDK use `npm`:
 
-    $ npm install @devoinc/browser-sdk
+    $ npm i @devoinc/browser-sdk
 
 Place this code including your
 [credentials](#Credentials)
@@ -524,13 +524,13 @@ Install all dependencies:
 
 ```
 cd browser-sdk
-npm install
+npm ci
 ```
 
 Make sure that everything runs fine:
 
 ```
-npm test
+npm t
 ```
 
 To run manual tests against our integration server run:
@@ -569,4 +569,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-


### PR DESCRIPTION
GH Actions are running a nonexistent command `build` instead of the much more useful and realistic `dist`.

Also, they are run under Node.js 12 among others, while [we specify that this works on versions of Node.js 14 and above](https://github.com/DevoInc/browser-sdk/blob/e9754e2c1faee57727216f184cc263b139f90c96/package.json#L90).