### PR TITLE
Feature: Memory saving with long rows

### DIFF
--- a/lib/fetchStreamReadable/fetchStreamReadable.js
+++ b/lib/fetchStreamReadable/fetchStreamReadable.js
@@ -147,14 +147,24 @@ async function processReader(
     let isDone = false;
     let isFirst = true;
     do {
-      const result = await reader.read();
-      isDone = result.done;
+      let downloaded = '';
+      let eolnFound = false;
+      while (!isDone && !eolnFound) {
+        let result = await reader.read();
+        let decoded = textDecoder.decode(result.value);
+        eolnFound = decoded.indexOf(separator) >= 0;
+        downloaded+= decoded;
+        isDone = result.done;
+        result = null;
+        decoded = null;
+      }
       await parseChunk(
-        result,
+        isDone,
+        downloaded,
         reader,
+        isErrorParsed(status),
         status,
         callbacks,
-        textDecoder,
         isFirst, // handle first chunk?
         separator
       );
@@ -174,11 +184,12 @@ async function processReader(
 
 
 async function parseChunk(
-  result,
+  done,
+  value,
   reader,
+  errorParsed,
   status,
   callbacks,
-  textDecoder,
   isFirst,
   separator,
 ) {
@@ -186,9 +197,9 @@ async function parseChunk(
     const timerId = setTimeout(() => {
       // When no more data needs to be consumed
       // or terminal error, break the reading
-      if (result.done || isErrorParsed(status)) {
+      if (done || errorParsed) {
         measurePerformance('b-sdk-parsing', 'b-sdk-start', 'b-sdk-parsing-end');
-        if (!isErrorParsed(status)) {
+        if (!errorParsed) {
           callbacks.processDone();
         }
         reader.releaseLock();
@@ -196,7 +207,7 @@ async function parseChunk(
         try {
           // console.table({bufferString: status.bufferString,
           //remains: status.remains, value: textDecoder.decode(value)});
-          status.bufferString += textDecoder.decode(result.value);
+          status.bufferString += value;
           parse({
             status,
             callbacks,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devoinc/browser-sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@devoinc/browser-sdk",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devoinc/browser-sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Devo browser SDK",
   "author": "Devo Dev Team",
   "eslintConfig": {

--- a/test/fetchStreamReadable.test.js
+++ b/test/fetchStreamReadable.test.js
@@ -106,7 +106,7 @@ describe('fetchStreamReadable', () => {
           done: 1,
         },
         finalState: states.EVENT,
-        bufferString: ''
+        out: extract(successfulAbbreviated),
       },
     ],
     [

--- a/test/fetchStreamReadable.test.js
+++ b/test/fetchStreamReadable.test.js
@@ -12,6 +12,8 @@ global.performance = performance; // performance polyfill for node
 this.processReader = processReader;
 
 this.processStream = processStream.bind(this);
+this.controller = { signal: { aborted: false }};
+
 const {
   successfulComplete1,
 } = require('./fetchStreamReadable/mocks/responses.js');
@@ -19,6 +21,8 @@ const {
 const {
   specificError1Response,
   invalidCredentialsErrorResponse } = require('./fetchStreamReadable/mocks/errorsResponses.js');
+
+const separator = '\n';
 
 const callbacks = {
   meta: spy(),
@@ -29,16 +33,52 @@ const callbacks = {
   abort: spy(),
 };
 
+const outData = {};
+function clearOut() {
+  Object.keys(outData).forEach(key => delete outData[key]);
+}
+function appendOut(key, data, flat) {
+  if (!outData[key]) outData[key] = [];
+  if (flat && Array.isArray(data))
+    data.forEach((d) => outData[key].push(d));
+  else
+    outData[key].push(data);
+}
+
 const callbacksWrap = {
-  processMeta: callbacks.meta,
-  processEvents: callbacks.data,
-  processProgress: callbacks.progress,
-  processError: callbacks.error,
+  processMeta: (m) => { appendOut('m', m); callbacks.meta(); },
+  processEvents: (d) => { appendOut('d', d, true); callbacks.data(); },
+  processProgress: (p) => { appendOut('p', p); callbacks.progress() },
+  processError: (e) => { appendOut('e', e); callbacks.error(); },
   processDone: callbacks.done,
   abort: callbacks.abort,
   pendingEvents: [],
   pendingData: [],
 };
+
+function extract(text, sep = separator) {
+  const lines = text.split(sep);
+  const result = {};
+  const add = (key1, data, key2 = key1, takeobject) => {
+    if (data[key2]) {
+      if (!result[key1]) result[key1] = [];
+      result[key1].push(takeobject ? data : data[key2]);
+      return true;
+    }
+    return false;
+  };
+  lines.forEach((line) => {
+    if (line.length === 0) return;
+    const json = JSON.parse(line);
+    add('m', json, 'metadata') || add('m', json);
+    add('d', json);
+    add('p', json);
+    add('e', json, 'error', true);
+    add('e', json, 'msg', true);
+    add('e', json, 'e', true);
+  });
+  return result;
+}
 
 describe('fetchStreamReadable', () => {
   before(function () {
@@ -54,19 +94,19 @@ describe('fetchStreamReadable', () => {
       'successfully read meta, events and progress with 2 breakpoints',
       {
         bufferString: successfulComplete1,
-        breakpoints: [20, successfulComplete1.length],
+        breakpoints: [20],
         isOk: true,
         statusCode: 200,
       },
       {
         callbacks: {
-          meta: 0,
-          data: 0,
-          progress: 0,
+          meta: 1,
+          data: 1, // 2 events, 1 call
+          progress: 1,
           done: 1,
         },
-        finalState: states.NOT_STARTED,
-        bufferString: '{"m":{"eventdate":{"type":"timestamp","index":0},"username":{"type":"str","index":1},"type":{"type":"str","index":2}},"metadata":[{"name":"eventdate","type":"timestamp"},{"name":"username","type":"str"},{"name":"type","type":"str"}]}\n{"p":[1601894800300]}\n{"d":[1601894807718,"fake@email.com","request"]}\n{"d":[1601894807720,"fake@email.com","response"]}\n'
+        finalState: states.EVENT,
+        out: extract(successfulComplete1),
       },
     ],
     [
@@ -86,7 +126,7 @@ describe('fetchStreamReadable', () => {
           done: 0
         },
         finalState: states.ERROR_PARSED,
-        bufferString: specificError1Response.substring(0, specificError1Response.length - 1)
+        out: extract(specificError1Response),
       }
     ],
     [
@@ -106,7 +146,7 @@ describe('fetchStreamReadable', () => {
           done: 0
         },
         finalState: states.ERROR_PARSED,
-        bufferString: invalidCredentialsErrorResponse.substring(0, invalidCredentialsErrorResponse.length - 1)
+        out: extract(invalidCredentialsErrorResponse),
       }
     ],
   ]).it('should %s', (message, input, expected, done) => {
@@ -115,17 +155,19 @@ describe('fetchStreamReadable', () => {
     const {
       callbacks: callbacksExpected,
       finalState,
-      bufferString: expectedBufferString
+      out,
     } = expected;
+
+    clearOut();
 
     this.processStream(
       MockReader.of(input.bufferString, input.breakpoints),
       callbacksWrap,
       input.isOk,
       input.statusCode,
-      '\r\n'
+      separator
     ).then((result) => {
-      result.bufferString.should.be.equal(expectedBufferString);
+      JSON.stringify(out).should.be.equal(JSON.stringify(outData));
       result.state.should.be.equal(finalState);
       Object.entries(callbacksExpected).forEach((entry) => {
         assert.callCount(callbacks[entry[0]], entry[1]);

--- a/test/fetchStreamReadable/MockUtils.js
+++ b/test/fetchStreamReadable/MockUtils.js
@@ -11,7 +11,8 @@ function str2ArrayBuffer(str) {
 }
 
 function* bufferRead(buffer) {
-  for (const chunk of buffer) {
+  while (buffer.length > 0) {
+    const chunk = buffer.shift();
     yield new Uint8Array(str2ArrayBuffer(chunk));
   }
 }
@@ -37,6 +38,10 @@ class MockReader {
 
   read() {
     return new Promise((resolve) => {
+      if (this.buffer.length === 0){
+        resolve({ done: true});
+        return;
+      }
       resolve(this.generator.next());
     });
   }


### PR DESCRIPTION
Some queries may return records several million characters long. In those cases, browser-sdk takes up much more memory than the downloaded information requires. This PR decreases the amount of memory required by reducing repeated function calls with a loop that does not take up memory in the JS heap.

@Worvast @tripu 