### PR TITLE
Fix vulnerability from transitive dependency (SNYK-JS-CRYPTOJS-6028119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Change log.
 
+## 3.1.5
+
+Fix vulns by updating transitive package (@devoinc/js-helper)
+-  https://security.snyk.io/vuln/SNYK-JS-CRYPTOJS-6028119
+
 ## 3.1.4
 
 Fix API error processing to avoid calling done callback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devoinc/browser-sdk",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@devoinc/browser-sdk",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devoinc/browser-sdk",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Devo browser SDK",
   "author": "Devo Dev Team",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "LinQ"
   ],
   "dependencies": {
-    "@devoinc/js-helper": "^2.0.1",
+    "@devoinc/js-helper": "^2.0.2",
     "abort-controller": "^3.0.0",
     "detect-browser": "^5.3.0",
     "fetch-readablestream": "^0.2.0",


### PR DESCRIPTION
Fix `SNYK-JS-CRYPTOJS-6028119` vulnerability by updating `@devoinc/js-helper` transitive dependency

- https://security.snyk.io/vuln/SNYK-JS-CRYPTOJS-6028119